### PR TITLE
Switching tabs now fires an event

### DIFF
--- a/px-tab-set.html
+++ b/px-tab-set.html
@@ -114,17 +114,7 @@ See <a href="#px-tab">px-tab</a> for more information about `px-tab`.
         this._changeTabStyle(old, false);
         this._changeTabStyle(tab, true);
 
-        this.fire('tabChanged', this._getTabIndex(tab), tab.id);
-      },
-
-      _getTabIndex: function(tab) {
-        var tabs = tab.parentElement.children;
-        for (var i = 0; i < tabs.length; i++) {
-          if (tabs[i] == tab) {
-            return i;
-          }
-        }
-        return -1;
+        this.fire('tabChanged', tab.id);
       },
 
       behaviors: [

--- a/px-tab-set.html
+++ b/px-tab-set.html
@@ -113,6 +113,18 @@ See <a href="#px-tab">px-tab</a> for more information about `px-tab`.
         //console.log('_tabChanged: old=' + old + ' new=' + tab);
         this._changeTabStyle(old, false);
         this._changeTabStyle(tab, true);
+
+        this.fire('tabChanged', this._getTabIndex(tab), tab.id);
+      },
+
+      _getTabIndex: function(tab) {
+        var tabs = tab.parentElement.children;
+        for (var i = 0; i < tabs.length; i++) {
+          if (tabs[i] == tab) {
+            return i;
+          }
+        }
+        return -1;
       },
 
       behaviors: [


### PR DESCRIPTION
Switching tabs fires an event with the tab index and tab id, if it exists.  This allows the containing page to perform actions, when applicable (e.g. making lazy API calls).